### PR TITLE
Updated code to keep it running on Ubuntu 22.04 / python 3.10.12 / March 2024

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 all:
     # install pycocotools locally
 	pip install -r requirements.txt
-	python setup.py build_ext --inplace
+	python3 setup.py build_ext --inplace
 	rm -rf build
 
 install:
 	# install pycocotools to the Python site-packages
-	python setup.py build_ext install
+	python3 setup.py build_ext install
 	rm -rf build

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Use the Makefile to install the coco-analyze api:
 ### Usage
 To run the extended multi-instance keypoint estimation error analysis: update the paths of the detections and annotations and execute the command line.
 
-    [annFile]  -> ./annotations/keypoints_val2014.json
+    [annFile]  -> ./annotations/person_keypoints_val2014.json
     [dtsFile]  -> ./detections/fakekeypoints100_keypoints_val2014_results.json
     [saveDir]  -> ./results/fakekeypoints100
     [teamName] -> fakekeypoints100

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To run the extended multi-instance keypoint estimation error analysis: update th
     [saveDir]  -> ./results/fakekeypoints100
     [teamName] -> fakekeypoints100
     [version]  -> 1.0
-    $ python run_analysis.py [annFile] [dtsFile] [saveDir] [teamName] [version]
+    $ python3 run_analysis.py [annFile] [dtsFile] [saveDir] [teamName] [version]
 
 ### Results
  - A summary file called `[teamName]_performance_report.tex` will be created once the analysis is complete.

--- a/analysisAPI/backgroundFalseNegErrors.py
+++ b/analysisAPI/backgroundFalseNegErrors.py
@@ -3,7 +3,8 @@ import os, time
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.path as mplPath
-from scipy.misc import imresize
+#from scipy.misc import imresize
+from skimage.transform import resize as imresize
 import skimage.io as io
 
 # package imports 

--- a/analysisAPI/backgroundFalsePosErrors.py
+++ b/analysisAPI/backgroundFalsePosErrors.py
@@ -3,7 +3,8 @@ import os, time
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.path as mplPath
-from scipy.misc import imresize
+#from scipy.misc import imresize
+from skimage.transform import resize as imresize
 import skimage.io as io
 
 # package imports 

--- a/analysisAPI/utilities.py
+++ b/analysisAPI/utilities.py
@@ -6,7 +6,8 @@ import matplotlib.pyplot as plt
 import matplotlib.path as mplPath
 from matplotlib.collections import PatchCollection
 from matplotlib.patches import Polygon
-from scipy.misc import imresize
+#from scipy.misc import imresize
+from skimage.transform import resize as imresize
 import skimage.io as io
 
 """

--- a/pycocotools/cocoeval.py
+++ b/pycocotools/cocoeval.py
@@ -447,6 +447,7 @@ class COCOeval:
                     tps = np.logical_and(               dtm,  np.logical_not(dtIg) )
                     fps = np.logical_and(np.logical_not(dtm), np.logical_not(dtIg) )
 
+                    np.float = float  #For Numpy > 1.20
                     tp_sum = np.cumsum(tps, axis=1).astype(dtype=np.float)
                     fp_sum = np.cumsum(fps, axis=1).astype(dtype=np.float)
                     for t, (tp, fp) in enumerate(zip(tp_sum, fp_sum)):
@@ -616,8 +617,13 @@ class Params:
         self.imgIds = []
         self.catIds = []
         # np.arange causes trouble.  the data point on arange is slightly larger than the true value
-        self.iouThrs = np.linspace(.5, 0.95, np.round((0.95 - .5) / .05) + 1, endpoint=True)
-        self.recThrs = np.linspace(.0, 1.00, np.round((1.00 - .0) / .01) + 1, endpoint=True)
+        #Switch from :
+        #self.iouThrs = np.linspace(.5, 0.95, np.round((0.95 - .5) / .05) + 1, endpoint=True)
+        #self.recThrs = np.linspace(.0, 1.00, np.round((1.00 - .0) / .01) + 1, endpoint=True)
+        #To :
+        self.iouThrs = np.linspace(.5, 0.95, int(np.round((0.95 - .5) / .05) + 1), endpoint=True)
+        self.recThrs = np.linspace(.0, 1.00, int(np.round((1.00 - .0) / .01) + 1), endpoint=True)
+        #Using this advice : https://github.com/matteorr/coco-analyze/issues/28 
         self.maxDets = [20]
         self.areaRng = [[0 ** 2, 1e5 ** 2], [32 ** 2, 96 ** 2], [96 ** 2, 1e5 ** 2]]
         self.areaRngLbl = ['all', 'medium', 'large']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
+pillow
+cython
+scipy
 colour
 numpy
 matplotlib
+jinja2
+scikit-image


### PR DESCRIPTION
The code has been updated with the following changes :

1) requirements now lists all requirements (including cython, scikit and others that where not there previously )
2) compatibility with numpy 1.21> np.float is fixed using the method suggested by numpy
3) imresize is no longer available using 
from scipy.misc import imresize 
and is replaced with 
from skimage.transform import resize as imresize
4) python calls have been replaced with python3 since python is no longer available if the python-is-python3 package is not installed

It is the first time using coco-analyze so unfortunately I have no data to compare against the previous version : 
however :
make all
python3 run_analysis.py ./annotations/person_keypoints_val2014.json ./detections/fakekeypoints100_keypoints_val2014_results.json ./results/fakekeypoints100 fakekeypoints100 1.0
seems to be working fine